### PR TITLE
feat: Implement slide enhancements and component placeholders

### DIFF
--- a/slidev-shared-ptr-presentation/components/ProgressTracker.vue
+++ b/slidev-shared-ptr-presentation/components/ProgressTracker.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="progress-tracker">
+    Slide {{ $slidev.nav.currentPage }} / {{ $slidev.nav.total }}
+  </div>
+</template>
+
+<style scoped>
+.progress-tracker {
+  position: fixed;
+  bottom: 10px;
+  right: 15px;
+  font-size: 0.8em;
+  color: #888;
+  background-color: rgba(0,0,0,0.1); /* Optional: for better visibility */
+  padding: 3px 8px;
+  border-radius: 3px;
+}
+</style>

--- a/slidev-shared-ptr-presentation/components/VisualRefCounter.vue
+++ b/slidev-shared-ptr-presentation/components/VisualRefCounter.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="visual-ref-counter">
+    <p class="label">Reference Count:</p>
+    <p class="count">{{ count }}</p>
+  </div>
+</template>
+
+<script setup>
+import { defineProps } from 'vue'
+
+defineProps({
+  count: {
+    type: Number,
+    required: true,
+    default: 0
+  }
+})
+</script>
+
+<style scoped>
+.visual-ref-counter {
+  background-color: rgba(128, 128, 128, 0.1);
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  padding: 15px;
+  border-radius: 8px;
+  text-align: center;
+  margin: 10px auto; /* Center block if it's not full width */
+  width: fit-content; /* Adjust width to content */
+}
+.label {
+  font-size: 0.9em;
+  color: #aaa;
+  margin-bottom: 5px;
+}
+.count {
+  font-size: 2.5em;
+  font-weight: bold;
+  color: #30c8c8; /* Using a color similar to cyan accents in the presentation */
+}
+</style>

--- a/slidev-shared-ptr-presentation/slides.md
+++ b/slidev-shared-ptr-presentation/slides.md
@@ -55,9 +55,8 @@ layout: default
 - Comparison with other Smart Pointers
 - Summary and Q&A
 
-<div class="absolute bottom-10 right-10 text-xs opacity-50">
-  Slide <SlideCurrentNo /> / <SlidesTotal />
-</div>
+<!-- Removed manual slide counter, replaced by ProgressTracker component -->
+<ProgressTracker />
 
 
 ---
@@ -108,9 +107,14 @@ layout: default
 
 Imagine your program's memory as a bucket. With raw pointers, if you forget to empty parts of it, it overflows!
 
+<div class="mt-4 text-center">
+  <img src="/images/memory-leak-visualization.gif" alt="Memory Leak Visualization" class="mx-auto mt-4 h-60 rounded-lg shadow-md">
+  <p class="text-sm opacity-85">Conceptual visualization of a memory leak.</p>
+</div>
+
 <div v-click class="mt-4">
   <img src="https://media.giphy.com/media/3oriO0OEd9QIDdllqo/giphy.gif" alt="Leaking Bucket" class="mx-auto h-72 rounded-lg shadow-lg">
-  <p class="text-center text-sm opacity-75">Visual representation of a memory leak (sort of!)</p>
+  <p class="text-center text-sm opacity-75">And here's a more... dramatic take!</p>
 </div>
 
 
@@ -348,11 +352,11 @@ To use `shared_ptr`, you need to include the `<memory>` header:
 <div v-click>
 ### Key Characteristics:
 <ul>
-  <li v-click> <span class="text-cyan-400">🤝 Shared Ownership:</span> Multiple pointers, one object.</li>
-  <li v-click> <span class="text-cyan-400">⏱️ Reference Counting:</span> Keeps track of owners.</li>
-  <li v-click> <span class="text-cyan-400">🗑️ Automatic Cleanup:</span> Deallocates when no owners remain.</li>
-  <li v-click> <span class="text-cyan-400">✅ Exception Safe:</span> Resources are released correctly.</li>
-  <!-- TODO: Add icons for each characteristic -->
+  <li v-click> <span class="text-cyan-400">🤝 [SO_icon] Shared Ownership:</span> Multiple pointers, one object.</li>
+  <li v-click> <span class="text-cyan-400">⏱️ [RC_icon] Reference Counting:</span> Keeps track of owners.</li>
+  <li v-click> <span class="text-cyan-400">🗑️ [AC_icon] Automatic Cleanup:</span> Deallocates when no owners remain.</li>
+  <li v-click> <span class="text-cyan-400">✅ [ES_icon] Exception Safe:</span> Resources are released correctly.</li>
+  <!-- TODO: Add icons for each characteristic - Placeholders [icon_name] added. Replace with actual <img> or SVG. -->
 </ul>
 </div>
 
@@ -433,8 +437,8 @@ layout: default
 <!-- TODO: Visual counter showing ref count increments/decrements -->
 <div class="p-4 border rounded-lg glassmorphic min-h-[150px] flex flex-col items-center justify-center mt-4">
   <p class="text-lg font-semibold mb-2">Visual Ref Count</p>
-  <p class="text-4xl font-bold text-cyan-400">Ref Count: <span class="animate-pulse">N</span></p>
-  <p class="mt-2 text-sm"><em>[Placeholder for a visual counter that updates as shared_ptrs are created/destroyed.]</em></p>
+  <VisualRefCounter :count="3" />
+  <p class="mt-2 text-sm"><em>This counter demonstrates the display. Full interactivity to come!</em></p>
 </div>
 </div>
 


### PR DESCRIPTION
This commit introduces several improvements and placeholders to the shared_ptr presentation:

1.  **Progress Tracker:**
    - Added a `ProgressTracker.vue` component that displays the current slide number and total slides (e.g., "Slide X / Y").
    - Integrated this component into the "Agenda" slide, replacing the previous manual slide counter.

2.  **Memory Leak Visualization:**
    - Added a placeholder `<img>` tag in `slides.md` for a memory leak visualization GIF (`/images/memory-leak-visualization.gif`).
    - This prepares the slide for a visual aid on memory leaks.

3.  **Shared_ptr Characteristic Icons:**
    - Inserted text-based placeholder icons (e.g., `[SO_icon]`) next to each key characteristic of `std::shared_ptr` (Shared Ownership, Reference Counting, Automatic Cleanup, Exception Safe).
    - The TODO comment has been updated to reflect that these are placeholders awaiting actual icons.

4.  **Visual Reference Counter:**
    - Created a `VisualRefCounter.vue` component to display a numerical reference count.
    - Integrated this component into the "How shared_ptr Works" slide with a static example count of 3. This serves as a visual placeholder for a future interactive version.

These changes address several TODOs in the presentation, focusing on improving navigation, visual aids, and component structure.